### PR TITLE
ACMEv2 requirements

### DIFF
--- a/config.js
+++ b/config.js
@@ -7,6 +7,8 @@ const productionDirectoryUrl = process.env.ACME_DIRECTORY_URL || 'https://acme-v
 const stagingDirectoryUrl = process.env.ACME_DIRECTORY_URL || 'https://acme-staging.api.letsencrypt.org'
 
 module.exports = {
+  'agent-name': 'ocelotconsulting.node.acme', 
+  'agent-version': '2.0',
   's3-account-bucket': process.env.S3_ACCOUNT_BUCKET || '<your-s3-account-config-bucket>',
   's3-cert-bucket': process.env.S3_CERT_BUCKET || '<your-s3-ssl-cert-bucket>',
   's3-folder': process.env.S3_CERT_FOLDER || '<folder-under-bucket>',

--- a/src/acme/getDiscoveryUrls.js
+++ b/src/acme/getDiscoveryUrls.js
@@ -3,6 +3,7 @@ const agent = require('superagent')
 
 const getDiscoveryUrls = (discoveryUrl) =>
   agent.get(`${config['acme-directory-url']}/directory`)
+  .set('User-Agent', `${config['agent-name']}/${config['agent-version']}`)
   .then((data) => data.body)
 
 module.exports = getDiscoveryUrls

--- a/src/acme/getNonce.js
+++ b/src/acme/getNonce.js
@@ -3,6 +3,7 @@ const agent = require('superagent')
 
 const getNonce = () =>
   agent.get(`${config['acme-directory-url']}/directory`)
+  .set('User-Agent', `${config['agent-name']}/${config['agent-version']}`)
   .then((data) => data.header['replay-nonce'])
   .catch((e) => {
     console.error(`Error getting nonce`, e)

--- a/src/acme/sendSignedRequest.js
+++ b/src/acme/sendSignedRequest.js
@@ -1,3 +1,4 @@
+const config = require('../../config')
 const getNonce = require('./getNonce')
 const RSA = require('rsa-compat').RSA
 const agent = require('superagent')
@@ -7,6 +8,7 @@ const sendSignedRequest = (payload, keypair, url) =>
   .then((data) =>
     agent.post(url)
     .send(RSA.signJws(keypair, new Buffer(JSON.stringify(payload)), data))
+    .set('User-Agent', `${config['agent-name']}/${config['agent-version']}`)
   )
 
 module.exports = sendSignedRequest


### PR DESCRIPTION
When reading RFC 7231 and a mention from Peter Waher, I noticed the client doesn't specify a custom user-agent. One should add one, to be able to find the source/origin. Code is napkin code on the buss that needs testing...